### PR TITLE
Fix sum() crash on non-array input

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -18,6 +18,7 @@ function capitalize(str) {
  * @returns {number}
  */
 function sum(numbers) {
+  if (!Array.isArray(numbers)) return 0;
   return numbers.reduce((a, b) => a + b, 0);
 }
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -20,6 +20,22 @@ describe('sum', () => {
   it('should return 0 for empty array', () => {
     assert.equal(sum([]), 0);
   });
+
+  it('should return 0 for null input', () => {
+    assert.equal(sum(null), 0);
+  });
+
+  it('should return 0 for undefined input', () => {
+    assert.equal(sum(undefined), 0);
+  });
+
+  it('should return 0 for string input', () => {
+    assert.equal(sum("hello"), 0);
+  });
+
+  it('should return 0 for non-array input', () => {
+    assert.equal(sum(42), 0);
+  });
 });
 
 describe('clamp', () => {


### PR DESCRIPTION
Closes #1

## Changes
- Add `Array.isArray` guard to `sum()` — returns 0 for null, undefined, string, number inputs
- Previously threw TypeError: Cannot read properties of null (reading 'reduce')

## Verification
- 4 new edge case tests added (null, undefined, string, number)
- All 11 tests pass (7 existing + 4 new)